### PR TITLE
fix: expresión regular que valida la id de seguimiento de Google Anal…

### DIFF
--- a/inc/utils/admin-content.php
+++ b/inc/utils/admin-content.php
@@ -204,7 +204,7 @@ MACHETE.utils = (function($){
 	return {
 		isAnalytics: function(str){
 			if (!str) return false;
-			return (/^(ua-\d{4,11}-\d{1,4})|(g(tm)?-[a-z0-9]{4,11})$/i).test(str.toString());			
+			return (/^(ua-\d{4,11}-\d{1,4})$|^(g(tm)?-[a-z0-9]{4,11})$/i).test(str.toString());			
 		}
 	}
 

--- a/inc/utils/class-machete-utils-module.php
+++ b/inc/utils/class-machete-utils-module.php
@@ -95,7 +95,7 @@ class MACHETE_UTILS_MODULE extends MACHETE_MODULE {
 
 		if ( ! empty( $options['tracking_id'] ) ) {
 
-			if ( ! preg_match( '/^(ua-\d{4,11}-\d{1,4})|(g(tm)?-[a-z0-9]{4,11})$/i', strval( $options['tracking_id'] ) ) ) {
+			if ( ! preg_match( '/^(ua-\d{4,11}-\d{1,4})$|^(g(tm)?-[a-z0-9]{4,11})$/i', strval( $options['tracking_id'] ) ) ) {
 				/*
 				Invalid Tracking ID. Accepted formats:
 					UA-1234567-12


### PR DESCRIPTION
En la página de configuración "Analytics y Código personalizado", la expresión regular permitía valores de ID incorrectos como: UA-12345678-1xxxxxxxx, xxxxxxxxG-123456ABCD o xxxxxxxxGTM-123456ABCD

Ahora cada expresión regular comparada no permite mas caracteres que los indicados.

![image](https://user-images.githubusercontent.com/2836337/151675909-8894cdeb-c2ee-40ed-8bc7-636aa46d9c5e.png)
