### PR TITLE
Explicitly define $machete as global

### DIFF
--- a/machete.php
+++ b/machete.php
@@ -45,6 +45,7 @@ require MACHETE_BASE_PATH . 'inc/class-machete.php';
 require MACHETE_BASE_PATH . 'inc/class-machete-module.php';
 
 // Include Machete modules.
+global $machete;
 $machete = new MACHETE();
 require MACHETE_BASE_PATH . 'inc/about/class-machete-about-module.php';
 require MACHETE_BASE_PATH . 'inc/cleanup/class-machete-cleanup-module.php';


### PR DESCRIPTION
When using WP-CLI, the `$machete` object in the `init` action is `null`, therefore causing things to explode there.

`Fatal error: Uncaught Error: Attempt to modify property "modules" on null in .../plugins/machete/machete.php:86`